### PR TITLE
feat(config.rs): add system-wide and user-specific configuration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,11 +124,9 @@ Each tab maintains independent settings, allowing you to optimize input and outp
 - 256 samples (5.3ms @48kHz)
 - 512 samples (10.7ms @48kHz)
 - 1024 samples (21.3ms @48kHz)
-- 2048 samples (42.7ms @48kHz) - **Maximum currently handled by PipeWire**
+- 2048 samples (42.7ms @48kHz)
 - 4096 samples (85.3ms @48kHz) 
 - 8192 samples (170.7ms @48kHz)
-
-**Note:** While higher buffer sizes can be configured, PipeWire currently has a practical maximum of 2048 samples for reliable operation. Settings above this may not function as expected.
 
 ## Building from Source
 


### PR DESCRIPTION
- Add generate_system_pipewire_config() for system-wide settings
- Add generate_global_audio_script() for comprehensive global configuration
- Support configuration in both system and user locations:
  - System-wide: /etc/pipewire/pipewire.conf.d/99-pro-audio.conf
  - User-specific:
    - ~/.config/pipewire/pipewire.conf.d/99-pro-audio.conf
    - ~/.config/wireplumber/main.lua.d/99-global-audio.lua
- Enhance WirePlumber rules with multiple device type matching:
  - Global input devices (alsa_input.*)
  - Global output devices (alsa_output.*)
  - Fallback for any audio device (Audio/*)
- Improve buffer size support (128 to 8192 samples):
  - Set default.clock.quantum and ALSA period size
  - Configure proper min/max quantum limits
- Refactor script structure for better compatibility
- Enhance error handling and verification
- Improve logging and status reporting